### PR TITLE
feat: TECH change brand color

### DIFF
--- a/packages/lib/CustomBranding.tsx
+++ b/packages/lib/CustomBranding.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 
 import { useBrandColors } from "@calcom/embed-core/embed-iframe";
 
-const BRAND_COLOR = "#292929";
+const BRAND_COLOR = "#2563EB";
 const BRAND_TEXT_COLOR = "#ffffff";
 const DARK_BRAND_COLOR = "#fafafa";
 


### PR DESCRIPTION
Change brand colour. Mainly to improve UI on this page:
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/110449633/230578682-da7bc63e-1fd6-44a7-bb88-c1b0df0745bd.png">

Other pages could be also impacted (I checked briefly other pages and everything looks ok), but this change will make cal.com look more similar to join.com.